### PR TITLE
fix: PR feedback, update satwatch version

### DIFF
--- a/satwatch/docker-compose.yml
+++ b/satwatch/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       APP_HOST: satwatch_web_1
       APP_PORT: 8080
   web:
-    image: ghcr.io/jpcummins/sat.watch:1.1.5@sha256:8fbdd04b01d1ab8fa5626a908622a1dc36fea1c93c24eb24b8213e0bb2a94b5a
+    image: ghcr.io/jpcummins/sat.watch:1.1.7@sha256:43662321c75fb08ff297beefb24f8d4fe0eb63912a64cf5f070b414779924e82
     restart: on-failure
     stop_grace_period: 1m
     environment:
-      DATABASE_URL: "postgresql://satwatch:satwatch@db:5432/satwatch?sslmode=disable"
+      DATABASE_URL: "postgresql://satwatch:satwatch@satwatch_db_1:5432/satwatch?sslmode=disable"
       ELECTRUM_HOST: $APP_ELECTRS_NODE_IP
       ELECTRUM_PORT: $APP_ELECTRS_NODE_PORT
       URL: "http://$DEVICE_DOMAIN_NAME:3883"
@@ -21,7 +21,8 @@ services:
       RPCPASSWORD: $APP_BITCOIN_RPC_PASS
     user: "1000:1000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
     image: docker.io/library/postgres:17@sha256:fe3f571d128e8efadcd8b2fde0e2b73ebab6dbec33f6bfe69d98c682c7d8f7bd
     restart: on-failure

--- a/satwatch/hooks/post-install
+++ b/satwatch/hooks/post-install
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Create the default username and password.
 for attempt in $(seq 1 3); do
-  if "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" run --rm web './create-user -admin -username satwatch -password satwatch'; then
+  if "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" run --rm web "./create-user -admin -username satwatch -password ${APP_PASSWORD}"; then
     echo "Successfully created default user"
     break
   else

--- a/satwatch/umbrel-app.yml
+++ b/satwatch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: satwatch
 category: bitcoin
 name: satwatch
-version: "1.1.5"
+version: "1.1.7"
 tagline: Bitcoin monitoring and real-time alerts
 description: >-
   sat.watch provides real-time monitoring of your Bitcoin.
@@ -24,8 +24,8 @@ gallery: []
 repo: https://github.com/jpcummins/sat.watch
 support: https://github.com/jpcummins/sat.watch/issues
 port: 3883
-path: ""
+path: "/app"
 defaultUsername: "satwatch"
-defaultPassword: "satwatch"
+deterministicPassword: true
 submitter: J.P. Cummins
 submission: https://github.com/getumbrel/umbrel-apps/pull/2723


### PR DESCRIPTION
This PR addresses some feedback:

* SMTP configuration is not required anymore. https://github.com/jpcummins/sat.watch/pull/9
* Fixed Remember Me https://github.com/jpcummins/sat.watch/pull/10
* Uses deterministic password (very cool! I didn't know this was a feature of Umbrel)
* Improved db configuration